### PR TITLE
Implement non-local database access

### DIFF
--- a/app/persistence/persistence.js
+++ b/app/persistence/persistence.js
@@ -3,9 +3,11 @@ var pg = require('pg');
 var iceboxuser = process.env.ICEBOX_DB_USER || 'iceboxuser';
 var iceboxpsw = process.env.ICEBOX_DB_PSW || 'testForIce';
 var iceboxname = process.env.ICEBOX_DB_NAME || 'icobox';
+var iceboxhost = process.env.ICEBOX_DB_HOST || 'localhost';
+var iceboxport = process.env.ICEBOX_DB_PORT || 5432;
 
 var connectionString = process.env.ICEBOX_DB_URL ||
-  `postgres://${iceboxuser}:${iceboxpsw}@localhost:5432/${iceboxname}`;
+  `postgres://${iceboxuser}:${iceboxpsw}@${iceboxhost}:${iceboxport}/${iceboxname}`;
 
 pg.defaults.poolSize = 20;
 


### PR DESCRIPTION
This allows the Icebox database to reside on a different server from the one running the service.

Fixes #10 