### PR TITLE
dep: update trim to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "express": "^4.13.4",
     "ip": "1.1.1",
     "pg": "^4.4.4",
-    "trim": "0.0.1"
+    "trim": "^1.0.1"
   },
   "devDependencies": {
     "jake": "latest",


### PR DESCRIPTION
Make Github shut up about the security issue in the "trim" package. I only tested `npm install`, however the trim package is trivial enough that I don't expect issues.

Here's the changelog of trim: https://github.com/Trott/trim/blob/main/CHANGELOG.md

Is this service even still in use? If it isn't, another option would be to set the repo status to "archived".